### PR TITLE
Support go 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-stretch
+FROM golang:1.10-stretch
 WORKDIR /go/src/github.com/JumboInteractiveLimited/Gandalf
 RUN echo "Pulling go dependencies" \
 	&& go get -v -u \

--- a/contract.go
+++ b/contract.go
@@ -70,7 +70,7 @@ func (c *Contract) Assert(t Testable) {
 // This uses the benchmark run counter instead of the Contract.Run field.
 func (c *Contract) Benchmark(b *testing.B) {
 	if c.Tested && c.notHonored {
-		b.Skipf("Contract %#v benchmark skipped as the contract was not honored by passing its test")
+		b.Skipf("Contract %s benchmark skipped as the contract was not honored by passing its test\n", c.Name)
 	}
 	errors := 0
 	for n := 0; n < b.N; n++ {

--- a/mmock_test.go
+++ b/mmock_test.go
@@ -90,7 +90,7 @@ func TestMMockExporter(t *testing.T) {
 			}
 			if strings.Contains(tc.Name, "Path") {
 				if !strings.Contains(mock.Request.Path, ":name") {
-					st.Fatal("Could not find ':name' in path that should be overriden '%s'", mock.Request.Path)
+					st.Fatalf("Could not find ':name' in path that should be overriden '%s'\n", mock.Request.Path)
 				}
 			}
 		})


### PR DESCRIPTION
Runs test with 1.10 and fix issues found by test vet.

Includes simplification of `report.sh` to use new coverage report over multiple packages.