### PR TITLE
Support mmock configuration over the network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN echo "Pulling go dependencies" \
 		github.com/fatih/color \
 		github.com/NodePrime/jsonpath \
 		github.com/jmartin82/mmock \
-		github.com/tidwall/gjson
+		github.com/tidwall/gjson \
+		gopkg.in/h2non/gock.v1
 COPY . .
 RUN echo "Testing gandalf" \
 	&& go test -v -cover -short github.com/JumboInteractiveLimited/Gandalf/...

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ../:/go/src/github.com/JumboInteractiveLimited/Gandalf
       - mmock:/mmock
     working_dir: /go/src/github.com/JumboInteractiveLimited/Gandalf/example
-    command: go test -v -bench . -benchmem -gandalf.colour -gandalf.mock-dest /mmock -gandalf.provider-host mock:8080 github.com/JumboInteractiveLimited/Gandalf/example
+    command: go test -v -bench . -benchmem -gandalf.colour -gandalf.mock-dest http://mock:8082 -gandalf.provider-host mock:8080 github.com/JumboInteractiveLimited/Gandalf/example
 
   mock:
     image: jordimartin/mmock

--- a/flags.go
+++ b/flags.go
@@ -42,10 +42,9 @@ var OverrideChaos bool
 // also override this wth the `-gandalf.mmock-skip` cli switch.
 var MockSkip bool
 
-// MockSleep sets the sleep period after exporting a mock definition set this
-// to the number of milliseconds to sleep or use the `-gandalf.mock-sleep` cli
-// switch.
-var MockSleep int
+// MockDelay sets the sleep/timeout period after exporting a mock definition. set this
+// to the number of milliseconds or use the `-gandalf.mock-delay` cli switch.
+var MockDelay int
 
 // Gandalf can be configured with custom flags given
 // to the `go test` command or be setting the respective
@@ -65,7 +64,7 @@ func init() {
 		"Skip exporting contract definitions to mmock.")
 	flag.BoolVar(&OverrideColour, "gandalf.colour", false,
 		"Override tty detection and force colour output.")
-	flag.IntVar(&MockSleep, "gandalf.mock-sleep", 250,
+	flag.IntVar(&MockDelay, "gandalf.mock-delay", 250,
 		"Override milliseconds to wait after exporting a mock definition.")
 	flag.StringVar(&MockSavePath, "gandalf.mock-dest", "./",
 		"Destination to use when saving mocks.")
@@ -78,6 +77,10 @@ func init() {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
+}
+
+func mockSaveAPI() bool {
+	return strings.HasPrefix(MockSavePath, "http")
 }
 
 // Takes into account override flags.

--- a/mmock_test.go
+++ b/mmock_test.go
@@ -86,7 +86,7 @@ func TestMMockExporter(t *testing.T) {
 			tc.Assert(t)
 			mock, err := readMMockDefinition(fmt.Sprintf("./%s.json", tc.Name))
 			if err != nil {
-				st.Fatalf("Could not read back mmock definition file due to error: %s", err)
+				st.Fatalf("Could not read back MMock definition file due to error: %s", err)
 			}
 			if strings.Contains(tc.Name, "Path") {
 				if !strings.Contains(mock.Request.Path, ":name") {

--- a/mmockclient.go
+++ b/mmockclient.go
@@ -1,0 +1,129 @@
+package gandalf
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jmartin82/mmock/definition"
+)
+
+type clientMMock struct {
+	base   *url.URL
+	client *http.Client
+}
+
+var getMMockClient = func() func() *clientMMock {
+	singleton := struct {
+		client *clientMMock
+		sync   sync.Once
+	}{}
+	return func() *clientMMock {
+		if singleton.client == nil && strings.HasPrefix(MockSavePath, "http") {
+			singleton.sync.Do(func() {
+				c := &http.Client{Timeout: time.Duration(MockDelay) * time.Millisecond}
+				u, err := url.Parse(MockSavePath)
+				if err != nil {
+					panic(fmt.Errorf("Could not construct mmock url due to error: %s", err))
+				}
+				singleton.client = &clientMMock{u, c}
+			})
+		}
+		return singleton.client
+	}
+}()
+
+func (self *clientMMock) constructURL(path string) (out *url.URL, err error) {
+	uri, err := url.Parse(path)
+	if err == nil {
+		out = self.base.ResolveReference(uri)
+	}
+	return
+}
+
+func (self *clientMMock) call(method, path, body string) (*http.Response, error) {
+	u, err := self.constructURL(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, u.String(), bytes.NewBuffer([]byte(body)))
+	if err != nil {
+		return nil, err
+	}
+	if method == http.MethodPut || method == http.MethodPost {
+		req.Header.Add("Content-Type", "application/json")
+	}
+	return self.client.Do(req)
+}
+
+func (self *clientMMock) getDefinitions() (out []definition.Mock, err error) {
+	resp, err := self.call("GET", "/api/mapping", "")
+	if err != nil {
+		return
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err == nil {
+		err = json.Unmarshal(body, &out)
+	}
+	return
+}
+
+func (self *clientMMock) sendDefinition(method string, mock definition.Mock) error {
+	muri := getMMockDefURI(mock)
+	bbody, err := json.Marshal(mock)
+	if err != nil {
+		return err
+	}
+	resp, err := self.call(method, "/api/mapping/"+muri, string(bbody))
+	if err != nil {
+		return err
+	}
+	if method == http.MethodPost && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("POST to MMock failed with status code %d", resp.StatusCode)
+	}
+	if method == http.MethodPut && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("PUT to MMock failed with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (self *clientMMock) createDefinition(mock definition.Mock) error {
+	return self.sendDefinition("POST", mock)
+}
+
+func (self *clientMMock) updateDefinition(mock definition.Mock) error {
+	return self.sendDefinition("PUT", mock)
+}
+
+func (self *clientMMock) upsertDefinition(mock definition.Mock) error {
+	all, err := self.getDefinitions()
+	if err != nil {
+		return err
+	}
+	exists := false
+	wanted := getMMockDefURI(mock)
+	for _, m := range all {
+		if getMMockDefURI(m) == wanted {
+			exists = true
+		}
+	}
+	do := self.createDefinition
+	if exists {
+		do = self.updateDefinition
+	}
+	return do(mock)
+}
+
+func getMMockDefURI(mock definition.Mock) string {
+	uri := mock.URI
+	if uri == "" {
+		uri = mock.Description
+	}
+	return uri
+}

--- a/mmockclient_test.go
+++ b/mmockclient_test.go
@@ -1,0 +1,229 @@
+package gandalf
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jmartin82/mmock/definition"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func urlOrFail(t *testing.T, rawurl string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		t.Fatalf("Could not parse %s to url due to error: %s", rawurl, err)
+	}
+	return u
+}
+
+func Test_clientMMock_constructURL(t *testing.T) {
+	type fields struct {
+		base   *url.URL
+		client *http.Client
+	}
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantUrl *url.URL
+		wantErr bool
+	}{
+		{
+			name: "clean",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			args:    args{""},
+			wantUrl: urlOrFail(t, "http://test:8082"),
+			wantErr: false,
+		},
+		{
+			name: "api",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			args:    args{"/api"},
+			wantUrl: urlOrFail(t, "http://test:8082/api"),
+			wantErr: false,
+		},
+		{
+			name: "api relative",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			args:    args{"api"},
+			wantUrl: urlOrFail(t, "http://test:8082/api"),
+			wantErr: false,
+		},
+		{
+			name: "api trailing",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			args:    args{"api/"},
+			wantUrl: urlOrFail(t, "http://test:8082/api/"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &clientMMock{
+				base:   tt.fields.base,
+				client: tt.fields.client,
+			}
+			gotUrl, err := self.constructURL(tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("clientMMock.constructURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotUrl, tt.wantUrl) {
+				t.Errorf("clientMMock.constructURL() = %v, want %v", gotUrl, tt.wantUrl)
+			}
+		})
+	}
+}
+
+func Test_clientMMock_getDefinitions(t *testing.T) {
+	defer gock.Off()
+	mocks := []definition.Mock{
+		definition.Mock{
+			URI:         "AAA",
+			Description: "BBB",
+			Request: definition.Request{
+				Method: "GET",
+				Path:   "/healthz",
+			},
+			Response: definition.Response{
+				StatusCode: 200,
+				Body:       "OK",
+			},
+		},
+	}
+	gock.New("http://test:8082").
+		Get("/api/mapping").
+		Reply(http.StatusOK).
+		JSON(mocks)
+	type fields struct {
+		base   *url.URL
+		client *http.Client
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantOut []definition.Mock
+		wantErr bool
+	}{
+		{
+			name: "get single",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			wantOut: mocks,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &clientMMock{
+				base:   tt.fields.base,
+				client: tt.fields.client,
+			}
+			gotOut, err := self.getDefinitions()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("clientMMock.getDefinitions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotOut, tt.wantOut) {
+				t.Errorf("clientMMock.getDefinitions() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func Test_clientMMock_sendDefinition(t *testing.T) {
+	defer gock.Off()
+	mock := definition.Mock{
+		URI:         "AAA",
+		Description: "BBB",
+		Request: definition.Request{
+			Method: "GET",
+			Path:   "/healthz",
+		},
+		Response: definition.Response{
+			StatusCode: 200,
+			Body:       "OK",
+		},
+	}
+	gock.New("http://test:8082").
+		Post("/api/mapping/AAA").
+		MatchType("json").
+		JSON(mock).
+		Reply(http.StatusCreated)
+	gock.New("http://test:8082").
+		Put("/api/mapping/AAA").
+		MatchType("json").
+		JSON(mock).
+		Reply(http.StatusOK)
+	type fields struct {
+		base   *url.URL
+		client *http.Client
+	}
+	type args struct {
+		method string
+		mock   definition.Mock
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "POST",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			args: args{
+				method: "POST",
+				mock: mock,
+			},
+			wantErr: false,
+		},
+		{
+			name: "PUT",
+			fields: fields{
+				base:   urlOrFail(t, "http://test:8082"),
+				client: &http.Client{Timeout: time.Second},
+			},
+			args: args{
+				method: "PUT",
+				mock: mock,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &clientMMock{
+				base:   tt.fields.base,
+				client: tt.fields.client,
+			}
+			if err := self.sendDefinition(tt.args.method, tt.args.mock); (err != nil) != tt.wantErr {
+				t.Errorf("clientMMock.sendDefinition() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #15

Changes:
- cli switch `-gandalf.mock-dest` can now take a URL (detected by starting with http) and send mocks to mmock via the network removing the need to sleep.
- cli switch `-gandalf.mock-sleep` is now called `-gandalf.mock-delay` as it is not always sleeping now